### PR TITLE
Add ability to enhance decoded data attached to request for e.g. loading data server-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ app.get('/protected',
   });
 ```
 
+### Loading Extra Data
+Rather than putting any or all session-related data into the JWT, you can provide a function that as the `enhancedLoadCallback` option that will
+be used to extend or update the decoded JWT data that gets added to the request object by the restify-jwt middleware.
+The signature of the function is `function(decoded, callback)`:
+* `decoded` (`Object`) - The decoded JWT key/value pairs
+* `callback` (`Function`) - The restify-jwt function that updates the request object on success and calls next middleware, or errors on failure
+
 ### Error handling
 
 The default behavior is to throw an error when the token is invalid, so you can add your custom logic to manage unauthorized access as follows:

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,8 @@ var async = require('async');
 
 var DEFAULT_REVOKED_FUNCTION = function(_, __, cb) { return cb(null, false); };
 
+var DEFAULT_EXTRA_LOAD_FUNCTION = function(decoded, cb) { return cb(null, decoded)};
+
 var getClass = {}.toString;
 function isFunction(object) {
   return object && getClass.call(object) == '[object Function]';
@@ -26,6 +28,7 @@ module.exports = function(options) {
   }
 
   var isRevokedCallback = options.isRevoked || DEFAULT_REVOKED_FUNCTION;
+  var enhancedLoadFunction = options.enhancedLoadFunction || DEFAULT_EXTRA_LOAD_FUNCTION;
 
   var _requestProperty = options.userProperty || options.requestProperty || 'user';
   var credentialsRequired = typeof options.credentialsRequired === 'undefined' ? true : options.credentialsRequired;
@@ -95,8 +98,14 @@ module.exports = function(options) {
       jwt.verify(token, secret, options, function(err, decoded) {
         if (err && credentialsRequired) return next(new restify.errors.InvalidCredentialsError(err));
 
-        req[_requestProperty] = decoded;
-        next();
+        enhancedLoadFunction(decoded, function(err, enhanced_decoded){
+          if (err) {
+            return next(err);
+          }
+
+          req[_requestProperty] = decoded;
+          next();
+        });
       });
     });
   };

--- a/test/extra_load_function.js
+++ b/test/extra_load_function.js
@@ -1,0 +1,44 @@
+var jwt = require('jsonwebtoken');
+var assert = require('assert');
+
+var restifyjwt = require('../lib');
+var restify = require('restify');
+
+describe('extra_load_function', function(){
+  var req = {};
+  var res = {};
+
+  it('should load extra data values if enhancedLoadFunction is set', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    var extraLoadCallback = function(decoded, cb){
+      decoded.extraFoo = 'foobar';
+      cb(null, decoded);
+    };
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    restifyjwt({secret: secret, enhancedLoadFunction: extraLoadCallback})(req, res, function() {
+      assert.equal('foobar', req.user.extraFoo);
+    });
+  });
+
+  it('should allow enhancedLoadFunction to indicate session expired', function() {
+    var secret = 'shhhhhh';
+    var token = jwt.sign({foo: 'bar'}, secret);
+
+    var extraLoadCallback = function(decoded, cb){
+      cb(new restify.errors.UnauthorizedError('The token has been revoked.'), {});
+    };
+
+    req.headers = {};
+    req.headers.authorization = 'Bearer ' + token;
+    restifyjwt({secret: secret, enhancedLoadFunction: extraLoadCallback})(req, res, function(err, decoded) {
+      assert.ok(err);
+      assert.equal(err.body.code, 'UnauthorizedError');
+      assert.equal(err.message, 'The token has been revoked.');
+    });
+  });
+
+});


### PR DESCRIPTION
I want to add the ability to send only a minimal number of values in the JWT token but still track more data server-side in a persistence store like e.g. redis.  I have added the enhancedLoadCallback option to the middleware to enable the ability, after a JWT has been successfully decoded, to do additional operations based on the content of the JWT.  Unit tests show a very simple example of "expiring" a session server-side, as well as enhancing one with fixed data in code.
