### PR TITLE
Add ability to specify payload post-processor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,13 @@ module.exports = function(options) {
       jwt.verify(token, secret, options, function(err, decoded) {
         if (err && credentialsRequired) return next(new restify.errors.InvalidCredentialsError(err));
 
+        if(options.processPayload && typeof(options.processPayload) === "function") {
+          try{
+            decoded = options.processPayload(decoded);
+          } catch (e) {
+            next(e);
+          }
+        }
         req[_requestProperty] = decoded;
         next();
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,7 @@ module.exports = function(options) {
       }
     }
 
+
     if (!token) {
       if (credentialsRequired) {
         return next(new restify.InvalidCredentialsError('No authorization token was found'));
@@ -74,7 +75,11 @@ module.exports = function(options) {
       }
     }
 
-    var payload = jwt.decode(token);
+    try {
+      var payload = jwt.decode(token);
+    } catch (e) {
+      return next(new restify.errors.InvalidCredentialsError('Token unable to be decoded'));
+    }
 
     async.parallel([
       function(callback){
@@ -91,7 +96,7 @@ module.exports = function(options) {
       }
 
       var secret = results[0];
-
+      
       jwt.verify(token, secret, options, function(err, decoded) {
         if (err && credentialsRequired) return next(new restify.errors.InvalidCredentialsError(err));
 


### PR DESCRIPTION
I found I wanted to specially format the token payload and parse it properly when being submitted so I added the ability to pass a processPayload function which runs on decoded token payload. This is not a big change.
