### PR TITLE
Support restify 4.x and more consistency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ module.exports = function(options) {
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
         } else {
-          return next(new restify.errors.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
+          return next(new restify.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
         }
       } else {
         return next(new restify.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
@@ -92,13 +92,13 @@ module.exports = function(options) {
       if (err) { return next(err); }
       var revoked = results[1];
       if (revoked){
-        return next(new restify.errors.UnauthorizedError('The token has been revoked.'));
+        return next(new restify.UnauthorizedError('The token has been revoked.'));
       }
 
       var secret = results[0];
 
       jwt.verify(token, secret, options, function(err, decoded) {
-        if (err && credentialsRequired) return next(new restify.errors.InvalidCredentialsError(err));
+        if (err && credentialsRequired) return next(new restify.InvalidCredentialsError(err));
 
         req[_requestProperty] = decoded;
         next();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "restify": "3.x"
   },
   "peerDependencies": {
-    "restify": "3.x"
+    "restify": "3.x || 4.x"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
Support restify 4.x in `package.json` since there are no changes that affect `restify-jwt`.
Also more consistent usage in `restify.<Error>` vs. `restify.errors.<Error>`.
