### PR TITLE
Use restify-errors to work with restify 4.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,8 @@ var unless = require('express-unless');
 var restify = require('restify');
 var async = require('async');
 
+var InvalidCredentialsError = require('restify-errors').InvalidCredentialsError;
+
 var DEFAULT_REVOKED_FUNCTION = function(_, __, cb) { return cb(null, false); };
 
 var getClass = {}.toString;
@@ -59,16 +61,16 @@ module.exports = function(options) {
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
         } else {
-          return next(new restify.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
+          return next(new InvalidCredentialsError('Format is Authorization: Bearer [token]'));
         }
       } else {
-        return next(new restify.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
+        return next(new InvalidCredentialsError('Format is Authorization: Bearer [token]'));
       }
     }
 
     if (!token) {
       if (credentialsRequired) {
-        return next(new restify.InvalidCredentialsError('No authorization token was found'));
+        return next(new InvalidCredentialsError('No authorization token was found'));
       } else {
         return next();
       }
@@ -98,7 +100,7 @@ module.exports = function(options) {
       var secret = results[0];
 
       jwt.verify(token, secret, options, function(err, decoded) {
-        if (err && credentialsRequired) return next(new restify.InvalidCredentialsError(err));
+        if (err && credentialsRequired) return next(new InvalidCredentialsError(err));
 
         req[_requestProperty] = decoded;
         next();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "restify": "3.x"
   },
   "peerDependencies": {
-    "restify": "3.x || 4.x"
+    "restify": "3.x || 4.x",
+    "restify-errors": "^3.1.0"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
Restify 4.x has outsourced the InvalidCredentialsError and other errors into the `restify-errors` package. So there is no more `require('restify').InvalidCredentialsError`.

Cheers
