### PR TITLE
Added restify-errors to support last version of restify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
 var jwt = require('jsonwebtoken');
 var unless = require('express-unless');
 var restify = require('restify');
+var errors = require('restify-errors');
 var async = require('async');
-
-var InvalidCredentialsError = require('restify-errors').InvalidCredentialsError;
 
 var DEFAULT_REVOKED_FUNCTION = function(_, __, cb) { return cb(null, false); };
 
@@ -61,16 +60,16 @@ module.exports = function(options) {
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
         } else {
-          return next(new InvalidCredentialsError('Format is Authorization: Bearer [token]'));
+          return next(new errors.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
         }
       } else {
-        return next(new InvalidCredentialsError('Format is Authorization: Bearer [token]'));
+        return next(new errors.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
       }
     }
 
     if (!token) {
       if (credentialsRequired) {
-        return next(new InvalidCredentialsError('No authorization token was found'));
+        return next(new errors.InvalidCredentialsError('No authorization token was found'));
       } else {
         return next();
       }
@@ -94,13 +93,13 @@ module.exports = function(options) {
       if (err) { return next(err); }
       var revoked = results[1];
       if (revoked){
-        return next(new restify.UnauthorizedError('The token has been revoked.'));
+        return next(new errors.UnauthorizedError('The token has been revoked.'));
       }
 
       var secret = results[0];
 
       jwt.verify(token, secret, options, function(err, decoded) {
-        if (err && credentialsRequired) return next(new InvalidCredentialsError(err));
+        if (err && credentialsRequired) return next(new errors.InvalidCredentialsError(err));
 
         req[_requestProperty] = decoded;
         next();

--- a/package.json
+++ b/package.json
@@ -35,16 +35,15 @@
   "dependencies": {
     "async": "^0.9.0",
     "express-unless": "^0.3.0",
-    "jsonwebtoken": "^5.0.0",
-    "restify-errors": "^4.3.0"
+    "jsonwebtoken": "^5.0.0"
   },
   "devDependencies": {
     "mocha": "1.x.x",
     "restify": "3.x"
   },
   "peerDependencies": {
-    "restify": "3.x || 4.x",
-    "restify-errors": "^3.1.0"
+    "restify": "3.x || 4.x || 5.x",
+    "restify-errors": "^4.3.0"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "async": "^0.9.0",
     "express-unless": "^0.3.0",
-    "jsonwebtoken": "^5.0.0"
+    "jsonwebtoken": "^5.0.0",
+    "restify-errors": "^4.3.0"
   },
   "devDependencies": {
     "mocha": "1.x.x",


### PR DESCRIPTION
With the new version of restify, `Errors`, which used to be available on the restify.errors namespace, now live in their own repository and are published independently on npm.
`restify-errors` can be used independently of restify in any of your other projects for customizable error classes and chained errors.

Now errors creation are updated.