### PR TITLE
Use restify-errors for use with restify > 4.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
 var jwt = require('jsonwebtoken');
 var unless = require('express-unless');
 var restify = require('restify');
+var restifyErrors = require('restify-errors');
 var async = require('async');
-
-var InvalidCredentialsError = require('restify-errors').InvalidCredentialsError;
 
 var DEFAULT_REVOKED_FUNCTION = function(_, __, cb) { return cb(null, false); };
 
@@ -61,16 +60,16 @@ module.exports = function(options) {
         if (/^Bearer$/i.test(scheme)) {
           token = credentials;
         } else {
-          return next(new InvalidCredentialsError('Format is Authorization: Bearer [token]'));
+          return next(new restifyErrors.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
         }
       } else {
-        return next(new InvalidCredentialsError('Format is Authorization: Bearer [token]'));
+        return next(new restifyErrors.InvalidCredentialsError('Format is Authorization: Bearer [token]'));
       }
     }
 
     if (!token) {
       if (credentialsRequired) {
-        return next(new InvalidCredentialsError('No authorization token was found'));
+        return next(new restifyErrors.InvalidCredentialsError('No authorization token was found'));
       } else {
         return next();
       }
@@ -94,13 +93,13 @@ module.exports = function(options) {
       if (err) { return next(err); }
       var revoked = results[1];
       if (revoked){
-        return next(new restify.UnauthorizedError('The token has been revoked.'));
+        return next(new restifyErrors.UnauthorizedError('The token has been revoked.'));
       }
 
       var secret = results[0];
 
       jwt.verify(token, secret, options, function(err, decoded) {
-        if (err && credentialsRequired) return next(new InvalidCredentialsError(err));
+        if (err && credentialsRequired) return next(new restifyErrors.InvalidCredentialsError(err));
 
         req[_requestProperty] = decoded;
         next();


### PR DESCRIPTION
modified error handling to use restify-errors for all instances of errors for compatibility with restify > 4.x